### PR TITLE
Fix device removed message always throwing an error

### DIFF
--- a/buttplug/client/client.py
+++ b/buttplug/client/client.py
@@ -141,6 +141,7 @@ class ButtplugClient(ButtplugClientConnectorObserver):
             self.device_added_handler(self.devices[da.device_index])
         elif isinstance(msg, DeviceRemoved):
             dr: DeviceRemoved = msg
+            device = self.devices.pop(dr.device_index)
             self.devices.remove(dr.device_index)
             self.device_removed_handler(dr.device_index)
         elif isinstance(msg, ScanningFinished):

--- a/buttplug/client/client.py
+++ b/buttplug/client/client.py
@@ -142,7 +142,6 @@ class ButtplugClient(ButtplugClientConnectorObserver):
         elif isinstance(msg, DeviceRemoved):
             dr: DeviceRemoved = msg
             device = self.devices.pop(dr.device_index)
-            self.devices.remove(dr.device_index)
             self.device_removed_handler(dr.device_index)
         elif isinstance(msg, ScanningFinished):
             self.scanning_finished_handler()


### PR DESCRIPTION
`dict.remove` isn't something that exists - I've changed it to `dict.pop` for you so that it doesn't throw an error every time.