### PR TITLE
device_removed_handlers get device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.2.2 (2022-07-03)
+
+## Bug Fixes
+
+- device_removed_handlers now correctly receive the removed ButtplugClientDevice rather than its integer id.
+
 # 0.2.1 (2021-12-12)
 
 ## Bug Fixes

--- a/buttplug/__init__.py
+++ b/buttplug/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 name = "buttplug"

--- a/buttplug/client/client.py
+++ b/buttplug/client/client.py
@@ -142,8 +142,9 @@ class ButtplugClient(ButtplugClientConnectorObserver):
             self.device_added_handler(self.devices[da.device_index])
         elif isinstance(msg, DeviceRemoved):
             dr: DeviceRemoved = msg
+            removed_device: ButtplugClientDevice = self.devices[dr.device_index]
             self.devices.pop(dr.device_index)
-            self.device_removed_handler(dr.device_index)
+            self.device_removed_handler(removed_device)
         elif isinstance(msg, ScanningFinished):
             self.scanning_finished_handler()
         elif isinstance(msg, Log):


### PR DESCRIPTION
device_removed_handlers now correctly receive the removed ButtplugClientDevice rather than its integer id.

Fixes #5 